### PR TITLE
Issues timezone

### DIFF
--- a/SPIFF_fns.cpp
+++ b/SPIFF_fns.cpp
@@ -253,7 +253,7 @@ int best_strength;
             memcpy(bestAP->macAddr, WiFi.BSSID(i), 6);
             bestAP->channel = WiFi.channel(i);
 	    Serial.printf("tzonestr = %s\n", tzonestr);
-	    uint32_t tzid = atol(tzonestr);
+	    uint32_t tzid = strtoul(tzonestr,NULL,0);
             bestAP->tzone = tzid;
             Serial.printf("best strength = %d, best ssid = %s, tz = %lu = %lx\n", best_strength, filessid, tzid, tzid);
             Serial.printf("best channel %d, best mac %02x:%02x:%02x:%02x:%02x:%02x\n", bestAP->channel,

--- a/my_WiFi.h
+++ b/my_WiFi.h
@@ -15,7 +15,7 @@
 typedef struct WiFiAP {
     char *ssid;
     char *pass;
-    int tzone;
+    uint32_t tzone;
 } WIFIAP;
 
 EXTERN WIFIAP AccessPoints[]


### PR DESCRIPTION
When using the firmware in the time zone TZ_CET, the time is changed to some strange time each time a wifi connection is made. The cause is a signed/unsigned bug: timezones are specified in unsigned 32-bit integer values, but the function `atol` is used (and this is a signed function).
```
tzonestr = 2730856407
best strength = -49, best ssid = xxxx, tz = 2147483647 = 7fffffff
```

Next to that in the struct WiFiAP, the timezone is specified signed, which could cause bugs. 

