### PR TITLE
Fix time zone bug when deleting wifi network

### DIFF
--- a/SPIFF_fns.cpp
+++ b/SPIFF_fns.cpp
@@ -413,7 +413,7 @@ int errcnt = 0;
 	Serial.printf("don't copy %s line to new file.\n", filessid);
       }
       else {
-	sprintf(buff, "%s\t%s\t%lu\n", filessid, pass, tzonestr);
+	sprintf(buff, "%s\t%s\t%s\n", filessid, pass, tzonestr);
 	Serial.printf("COPY: '%s'\n", buff);
 	if(ofile.print(buff)){
 	  Serial.println(F("- copy succeeded"));


### PR DESCRIPTION
After running the app 'Delete Wifi' and deleting an access point, the time zone information of all wifi networks is lost. This fixes it.